### PR TITLE
Passing configs for adapter when put in buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,17 @@
 
 ## Installing the module
 ```bash
-npm i logtify
+npm i -S logtify
 ```
 
 This module uses RxJs library to implement a pub-sub model.
-
-Each subscriber contains a ``handle`` function, which accepts ``Message``.
-
-If needed, new subscribers and adapters can be added to the stream.
 
 ## Configuration
 ### Minimal
 ```js
 const { logger } = require('logtify')();
 ```
-### Parameters
-You can configure the stream by passing the following parameters or setting up the environment variables.
+### Config properties
 
 ```js
 // Note, that such settings will be passed to each subscriber:
@@ -38,15 +33,9 @@ LOGTIFY_BUFFER_SIZE = 1; // amount of log messages that will be kept in buffer b
 **NOTE!** Environment variables have a higher priority over the settings object
 
 ### Add new subscriber
-By default, logtify contains only 1 subscriber - `Console`. However, you can add new subscruber as the following:
-```js
-require('logtify-logentries')();
-require('logtify-bugsnag')();
-const { logger } = require('logtify')();
-```
+A subscriber is a small independent logger unit, whose job is to send logs to (ideally) one service/node.
 
-### Preconfigure subscriber
-If you need to preconfigure the subscriber before adding it to the stream, you can do it like this:
+By default, logtify contains only 1 subscriber - `Console`. However, you can add new subscruber as the following:
 ```js
 // these settings are subscriber-specific and will only be received by this subscriber
 require('logtify-logentries')({ LOGS_TOKEN: 'YOUR_LOGENTRIES_TOKEN' });
@@ -55,23 +44,17 @@ const { logger } = require('logtify')();
 ```
 
 ### Add adapter
+An adapter is a small plugin, meant to ease the usage of some subscriber.
+
 If a subscriber provides an adapter, it will be exposed in the logtify instance
 ```js
-require('logtify-bugsnag');
+require('logtify-bugsnag')();
 const { logger, notifier } = require('logtify')();
 ```
 
-__However, be aware!__ If you import he subscriber with adapter __after__ you initialize the stream, you need to update the reference.
+__However, be aware!__ If you import he subscriber with adapter __after__ you initialize the stream, you need to update the logtify reference, because __adapter property will be undefined__.
 
-```js
-const { logger, notifier } = require('logtify')();
-// notifier is undefined
-require('logtify-bugsnag');
-const { logger, notifier } = require('logtify')();
-// notifier is Object 
-```
-
-### Logger (Winston adapter) usage:
+### Logger usage:
 ```js
 const { logger } = require('logtify')();
 
@@ -84,8 +67,6 @@ logger.error(new Error('Hello world'));
 logger.log('info', 'Hello world');
 
 logger.profile('label');
-
-logger.stream // access to stream
 ```
 
 ### Stream Usage:
@@ -99,20 +80,18 @@ stream.unbindAdapter('name')    // remove adapter
 stream.subscribe(subscriber)     // add a subscriber
 
 // properties
-stream.settings;     // { Object }
-stream.adapters;     // { Map }
+stream.settings;         // Object
+stream.adapters;         // Map
+stream.subscribersCount; // Number
 
 // classes
-stream.Message;      // { Object }
-stream.Subscriber;      // { Object }
+stream.Message;          // Object
+stream.Subscriber;       // Object
 ```
 
-### Interface
+### Message format
 
-### Internal implementation details
-Firstly, you call any logging function from either ``logger`` or ``stream``.
-
-Then provided data is then converted into a message package object of the following structure:
+Then provided data is converted into a message package object of the following structure:
 
 ```js
 // if text message
@@ -130,21 +109,6 @@ Then provided data is then converted into a message package object of the follow
 ```
 
 Each subscriber receives identical copy of a message.
-
-## Tweaking
-As mentioned, a module can be configured with either a settings object or env variables.
-
-A subscriber will process a message if all the 3 steps are done:
-* A subscriber is configured and ready
-* A subscriber will be used
-* A message is present
-
-Default:
-* A Console subscriber is always ready
-* A Console subscriber will be used if ``CONSOLE_LOGGING !== 'false'`` either as an env var or a property in the settings object
-* A message will be sent if ``message.level`` >= ``MIN_LOG_LEVEL_CONSOLE || MIN_LOG_LEVEL`` (env or settings prop)
-
-To change the default logic, change the values of the mentioned properties.
 
 ### Default logLevel priority:
 - silly -> 0
@@ -165,44 +129,7 @@ The minimal requirements for a subscriber is to have the following:
 * handle(message) function, that passes the message further after it's logic
 * a constructor should consume ``settings`` object, which will be injected when during a link initialization
 
-* To be able to preconfigure the subscriber before automatic initialization within the stream, it should expose a wrapper function as the following:
-```js
-module.exports = (settings) => {
-  // some logic with the configuration
-}
-```
-
-To let ``logtify`` automatically tie the subscriber to the main stream, it should use one of the streamBuffer's functions:
-- addSubscriber(subscriber)
-or 
-- addAdapter(adapter)
-
-This is how you get the streamBuffer object from the logtify module.
-__Make sure to not provide any configurations to the stream and let user do it at the right moment.__
-```js
-const logtify = require('logtify');
-const streamBuffer = logtify.streamBuffer;
-const { stream } = logtify();
-```
-* in the settings function, it should construct the following object and add it to the stream buffer
-```js
-const subscriberData = {
-  class: MySubscriberClass,
-  config: configs
-};
-
-streamBuffer.addSubscriber(subscriberData);
-// take the global settings
-const mergedConfigs = Object.assign({}, configs, stream.settings);
-stream.subscribe(new Logstash(mergedConfigs));
-```
-
-Thanks to the ``streamBuffer``, if the subscriber will be ``required`` before the ``logtify`` module is initialized:
-```js
-require('logtify-my-custom-subscriber')();
-const logtify = require('logtify')();
-```
-It will be added automatically
+Please refer to [Dev Tips](https://github.com/dial-once/node-logtify/wiki) for more information on the topic
 
 ## Prefixing
 Subscribers may include prefixes into a message. For example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "logtify",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "dependencies": {
     "abbrev": {
@@ -10,9 +10,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
-      "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -113,15 +113,15 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true
     },
     "browser-stdout": {
@@ -333,9 +333,9 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.22",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.22.tgz",
-      "integrity": "sha512-YXTXSlZkJsVwMEVljp1Bh5P9+Raa3524OMl9kywGMp1aazKTCnAqORRL/8dkuqNHk+LRYe0LezuS8PlUt3+mOw==",
+      "version": "0.10.23",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
       "dev": true
     },
     "es6-iterator": {
@@ -419,35 +419,21 @@
       "dev": true
     },
     "eslint-import-resolver-node": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz",
-      "integrity": "sha1-Wt2BBujJKNssuiMrzZ76hG49oWw=",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
+      "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
       "dev": true
     },
     "eslint-module-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz",
-      "integrity": "sha1-pvjCHZATWHWc3DXbrBmCrh7li84=",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        }
-      }
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+      "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+      "dev": true
     },
     "eslint-plugin-import": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.3.0.tgz",
-      "integrity": "sha1-N8gB4K2g4pbL3yDD85OstbUq82s=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
+      "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
       "dev": true,
       "dependencies": {
         "doctrine": {
@@ -497,18 +483,10 @@
       "dev": true
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
-      "dev": true,
-      "dependencies": {
-        "estraverse": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-          "dev": true
-        }
-      }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -612,9 +590,9 @@
       "dev": true
     },
     "globals": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-      "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
@@ -673,10 +651,16 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true
     },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
     "hosted-git-info": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "ignore": {
@@ -849,9 +833,9 @@
       }
     },
     "js-tokens": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
-      "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
       "dev": true
     },
     "js-yaml": {
@@ -914,6 +898,20 @@
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -1068,9 +1066,9 @@
       "dev": true
     },
     "normalize-package-data": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true
     },
     "number-is-nan": {
@@ -1133,6 +1131,18 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+      "dev": true
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true
     },
     "parse-json": {
@@ -1240,9 +1250,9 @@
       }
     },
     "readable-stream": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
-      "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "dev": true
     },
     "readline2": {
@@ -1313,14 +1323,14 @@
       "dev": true
     },
     "rxjs": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.1.tgz",
-      "integrity": "sha1-ti91fyeURdJloYpY+wpw3JDpFiY="
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.2.tgz",
+      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc="
     },
     "safe-buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-      "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "samsam": {
@@ -1336,9 +1346,9 @@
       "dev": true
     },
     "shelljs": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
-      "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true
     },
     "sinon": {
@@ -1390,9 +1400,9 @@
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true
     },
     "string-width": {
@@ -1436,6 +1446,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -1443,9 +1459,15 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true
         }
       }
@@ -1481,9 +1503,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.27",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.27.tgz",
-      "integrity": "sha1-R3h/kSsPJC5bmENDvo416V9pTJw=",
+      "version": "2.8.29",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
       "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -210,16 +210,28 @@ module.exports = (config) => {
       if (CustomSubscriber.adapter !== null && typeof CustomSubscriber.adapter === 'object') {
         const adapter = CustomSubscriber.adapter;
         adapters = Object.assign({}, adapters, {
-          [adapter.name]: adapter.class
+          [adapter.name]: {
+            class: adapter.class,
+            config: CustomSubscriber.config
+          }
         });
       }
     }
   }
-  // Custom adapters
-  // adapter key-value objects: { name -> constructor  }
+  /* Custom adapters
+     adapter key-value objects:
+     {
+      [name]: {
+        class: constructor,
+        config: { Object } // optional
+      }
+     }
+  */
   if (adapters !== null && typeof adapters === 'object') {
     for (const adapterName of Object.keys(adapters)) {
-      stream.bindAdapter(adapterName, new adapters[adapterName](stream, settings));
+      const AdapterClass = adapters[adapterName].class;
+      const adapterSettings = Object.assign({}, adapters[adapterName].config, settings);
+      stream.bindAdapter(adapterName, new AdapterClass(stream, adapterSettings));
     }
   }
 

--- a/src/modules/stream-buffer.js
+++ b/src/modules/stream-buffer.js
@@ -32,7 +32,7 @@ class StreamBuffer {
       this.subscribers.push(CustomSubscriber);
       // if a pre-configured object also exposes adapter
       if (CustomSubscriber.adapter !== null && typeof CustomSubscriber.adapter === 'object') {
-        this.addAdapter(CustomSubscriber.adapter);
+        this.addAdapter(CustomSubscriber.adapter, CustomSubscriber.config);
       }
     }
   }
@@ -40,8 +40,9 @@ class StreamBuffer {
   /**
    * @function addAdapter - adds subscriber adapter to the buffer
    * @param adapter {object} - adapter object
+   * @param config {object} - config object for adapter. Optional
    */
-  addAdapter(adapter) {
+  addAdapter(adapter, config) {
     // Custom adapters
     // adapter key-value objects: { name -> constructor  }
     if (adapter !== null && typeof adapter === 'object') {
@@ -49,10 +50,11 @@ class StreamBuffer {
         assert(typeof adapter.name === 'string');
         assert(typeof adapter.class === 'function');
         Object.assign(this.adapters, {
-          [adapter.name]: adapter.class
+          [adapter.name]: {
+            class: adapter.class,
+            config
+          }
         });
-      } else {
-        Object.assign(this.adapters, adapter);
       }
     }
   }

--- a/test/chain-spec.js
+++ b/test/chain-spec.js
@@ -86,7 +86,8 @@ describe('Logger stream ', () => {
   it('should support custom subscribers', () => {
     const { streamBuffer } = logtify;
     streamBuffer.addAdapter({
-      unicorn: WinstonAdapter
+      name: 'unicorn',
+      class: WinstonAdapter
     });
     streamBuffer.addSubscriber(ConsoleSubscriber);
     streamBuffer.addSubscriber(ConsoleSubscriber);
@@ -105,7 +106,8 @@ describe('Logger stream ', () => {
       class: WinstonAdapter
     });
     streamBuffer.addAdapter({
-      unicorn: WinstonAdapter
+      name: 'unicorn',
+      class: WinstonAdapter
     });
     const { stream, logger, unicorn } = logtify({});
     assert(stream);
@@ -116,10 +118,12 @@ describe('Logger stream ', () => {
   it('should be able to unbind adapter', () => {
     const { streamBuffer } = logtify;
     streamBuffer.addAdapter({
-      stream: WinstonAdapter
+      name: 'stream',
+      class: WinstonAdapter
     });
     streamBuffer.addAdapter({
-      unicorn: WinstonAdapter
+      name: 'unicorn',
+      class: WinstonAdapter
     });
     let { stream, unicorn } = logtify({});
     assert(stream);


### PR DESCRIPTION
If a subscriber contained an adapter (bugsnag) and was configured with some vars:
```
require('logtify-bugsnag')({ BUGS_TOKEN: '123abc' });
```
In case it was required __before__ the main module, the config for adapter was lost.

Also removed some redundant, too detailed documentation