### PR TITLE
Add tracer to build prefix with info about caller module

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ process.env.LOG_TIMESTAMP = 'true';
 process.env.LOG_ENVIRONMENT = 'true';
 process.env.LOG_LEVEL = 'true';
 process.env.LOG_REQID = 'true';
+process.env.LOG_CALLER_PREFIX = 'true';
 ```
 
 **Note!** that if the ``LOG_REQID`` is set to ``'true'``, it will still not log it (as seen from example above), unless it is provided in the ``message.meta``.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ process.env.LOG_REQID = 'true';
 process.env.LOG_CALLER_PREFIX = 'true';
 ```
 
+LOG_CALLER_PREFIX - enables/disables printing of additional prefix: `[project:module:function]` with information about the caller project
+
 **Note!** that if the ``LOG_REQID`` is set to ``'true'``, it will still not log it (as seen from example above), unless it is provided in the ``message.meta``.
 So, to include it, you should do the following:
 ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "logtify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.0.9",
@@ -20,6 +21,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -33,7 +37,11 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -45,7 +53,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "kind-of": "3.2.2",
+        "longest": "1.0.1",
+        "repeat-string": "1.6.1"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
@@ -75,13 +88,19 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -93,7 +112,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.7.0"
+      }
     },
     "arrify": {
       "version": "1.0.1",
@@ -110,7 +133,12 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
       "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -122,7 +150,11 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "browser-stdout": {
       "version": "1.3.0",
@@ -140,7 +172,10 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -160,13 +195,24 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4",
+        "lazy-cache": "1.0.4"
+      }
     },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "circular-json": {
       "version": "0.3.1",
@@ -178,7 +224,10 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -192,6 +241,11 @@
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "center-align": "0.1.3",
+        "right-align": "0.1.3",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -223,7 +277,10 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-readlink": "1.0.1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -235,7 +292,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "contains-path": {
       "version": "0.1.0",
@@ -258,7 +320,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.23"
+      }
     },
     "damerau-levenshtein": {
       "version": "1.0.4",
@@ -270,7 +335,10 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
@@ -294,13 +362,26 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
     },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "diff": {
       "version": "3.2.0",
@@ -312,61 +393,113 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
     },
     "es-abstract": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
       "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.0",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
     },
     "es-to-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.23",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
       "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -379,6 +512,13 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
+      "requires": {
+        "esprima": "2.7.3",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -398,19 +538,65 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
     },
     "eslint": {
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.8",
+        "doctrine": "2.0.0",
+        "escope": "3.6.0",
+        "espree": "3.4.3",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.8.4",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      }
     },
     "eslint-config-airbnb": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-13.0.0.tgz",
       "integrity": "sha1-aI0V08J2wMdTrlOMkqRDl9dq5G4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "eslint-config-airbnb-base": "10.0.1"
+      }
     },
     "eslint-config-airbnb-base": {
       "version": "10.0.1",
@@ -422,25 +608,49 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.1.tgz",
       "integrity": "sha512-yUtXS15gIcij68NmXmP9Ni77AQuCN0itXbCc/jWd8C6/yKZaSNXicpC8cgvjnxVdmfsosIXrjpzFq7GcDryb6A==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "resolve": "1.3.3"
+      }
     },
     "eslint-module-utils": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
       "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.8",
+        "pkg-dir": "1.0.0"
+      }
     },
     "eslint-plugin-import": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
       "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
       "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1",
+        "contains-path": "0.1.0",
+        "debug": "2.6.8",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.1",
+        "eslint-module-utils": "2.1.1",
+        "has": "1.0.1",
+        "lodash.cond": "4.5.2",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0"
+      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
         }
       }
     },
@@ -448,19 +658,35 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-2.2.3.tgz",
       "integrity": "sha1-TjXLcbin23AqxBXIBuuOjZ6mxl0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "damerau-levenshtein": "1.0.4",
+        "jsx-ast-utils": "1.4.1",
+        "object-assign": "4.1.1"
+      }
     },
     "eslint-plugin-react": {
       "version": "6.10.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
       "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
+      "requires": {
+        "array.prototype.find": "2.0.4",
+        "doctrine": "1.5.0",
+        "has": "1.0.1",
+        "jsx-ast-utils": "1.4.1",
+        "object.assign": "4.0.4"
+      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
         }
       }
     },
@@ -468,7 +694,11 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "acorn": "5.1.1",
+        "acorn-jsx": "3.0.1"
+      }
     },
     "esprima": {
       "version": "3.1.3",
@@ -480,13 +710,20 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
     },
     "estraverse": {
       "version": "4.2.0",
@@ -504,7 +741,11 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -527,25 +768,43 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -557,7 +816,10 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "samsam": "1.1.2"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -581,13 +843,24 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
     },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -599,7 +872,15 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -624,6 +905,12 @@
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "optimist": "0.6.1",
+        "source-map": "0.4.4",
+        "uglify-js": "2.8.29"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
@@ -635,7 +922,10 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
         }
       }
     },
@@ -643,13 +933,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "has-flag": {
       "version": "1.0.0",
@@ -679,7 +975,11 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -691,7 +991,22 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.1.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
     },
     "interpret": {
       "version": "1.0.3",
@@ -715,7 +1030,10 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-callable": {
       "version": "1.1.3",
@@ -733,13 +1051,22 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
       "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -751,13 +1078,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-property": {
       "version": "1.0.2",
@@ -769,13 +1102,19 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
     },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -805,6 +1144,22 @@
       "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
+      "requires": {
+        "abbrev": "1.0.9",
+        "async": "1.0.0",
+        "escodegen": "1.8.1",
+        "esprima": "2.7.3",
+        "glob": "5.0.15",
+        "handlebars": "4.0.10",
+        "js-yaml": "3.8.4",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6",
+        "once": "1.4.0",
+        "resolve": "1.1.7",
+        "supports-color": "3.2.3",
+        "which": "1.2.14",
+        "wordwrap": "1.0.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "2.7.3",
@@ -816,7 +1171,14 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "resolve": {
           "version": "1.1.7",
@@ -828,7 +1190,10 @@
           "version": "3.2.3",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -842,13 +1207,20 @@
       "version": "3.8.4",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "3.1.3"
+      }
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "json3": {
       "version": "3.3.2",
@@ -878,7 +1250,10 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-buffer": "1.1.5"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
@@ -891,19 +1266,33 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      }
     },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
@@ -923,7 +1312,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -959,7 +1352,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -977,7 +1375,12 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lolex": {
       "version": "1.3.2",
@@ -995,7 +1398,10 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "0.0.8",
@@ -1007,25 +1413,52 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mocha": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
       "integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
       "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.0",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.6.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
           "integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.2"
+          }
         },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "ms": {
           "version": "0.7.2",
@@ -1037,7 +1470,10 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
           "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
         }
       }
     },
@@ -1063,13 +1499,22 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "abbrev": "1.0.9"
+      }
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.3.0",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -1093,13 +1538,21 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
       "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.0",
+        "object-keys": "1.0.11"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -1112,6 +1565,10 @@
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
@@ -1125,7 +1582,15 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -1143,19 +1608,28 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "p-limit": "1.1.0"
+      }
     },
     "parse-json": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
     },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1179,7 +1653,10 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
       "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pify": "2.3.0"
+      }
     },
     "pify": {
       "version": "2.3.0",
@@ -1197,13 +1674,19 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pkg-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "find-up": "1.1.2"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -1233,19 +1716,31 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
       "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
     },
     "read-pkg-up": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      },
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
         }
       }
     },
@@ -1253,19 +1748,36 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "resolve": "1.3.3"
+      }
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -1277,13 +1789,20 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
       "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -1295,26 +1814,39 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "align-text": "0.1.4"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -1325,7 +1857,10 @@
     "rxjs": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.2.tgz",
-      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc="
+      "integrity": "sha1-KjI2/L8D31e64G/Wly/ZnlwI/Pc=",
+      "requires": {
+        "symbol-observable": "1.0.4"
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -1349,13 +1884,24 @@
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
+      }
     },
     "sinon": {
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
       "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "formatio": "1.1.1",
+        "lolex": "1.3.2",
+        "samsam": "1.1.2",
+        "util": "0.10.3"
+      }
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -1368,13 +1914,19 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
       "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -1403,19 +1955,30 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -1445,6 +2008,14 @@
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.0"
+      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -1462,13 +2033,20 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
           "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
         },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
         }
       }
     },
@@ -1494,7 +2072,10 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
@@ -1508,6 +2089,11 @@
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
       "optional": true,
+      "requires": {
+        "source-map": "0.5.6",
+        "uglify-to-browserify": "1.0.2",
+        "yargs": "3.10.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.6",
@@ -1529,13 +2115,19 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -1555,13 +2147,20 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "which": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "window-size": {
       "version": "0.1.0",
@@ -1573,7 +2172,15 @@
     "winston": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk="
+      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -1591,7 +2198,10 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "xtend": {
       "version": "4.0.1",
@@ -1604,7 +2214,13 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
       "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "camelcase": "1.2.1",
+        "cliui": "2.1.0",
+        "decamelize": "1.2.0",
+        "window-size": "0.1.0"
+      }
     }
   }
 }

--- a/src/modules/message.js
+++ b/src/modules/message.js
@@ -1,3 +1,5 @@
+const tracer = require('./tracer.js');
+
 /**
   @class Message
   Convert the given parameters into a correct message format
@@ -28,7 +30,7 @@ class Message {
       const metaData = metas.reduce((sum, next) => Object.assign({}, sum, next));
       Object.assign(this.payload.meta, metaData);
     }
-    this.prefix = null;
+    this.callerModuleInfo = tracer.trace();
   }
 
   /**
@@ -39,6 +41,7 @@ class Message {
     - LOG_ENVIRONMENT {'true'|'false'} - include current environment into a message prefix
     - LOG_LEVEL {'true'|'false'} - include log level in UPPERCASE into a message prefix
     - LOG_REQID {'true'|'false'} - incldue a reqId into a message prefix
+    - LOG_CALLER_PREFIX {'true'|'false'} - incldue a caller prefix of type module:project:function
 
     reqId will be included only if provided in the message meta
 
@@ -47,32 +50,43 @@ class Message {
     @return {object} - Prefix for the log message. Or an empty string of no prefix data logging is enabled
   **/
   getPrefix(settings = {}, delimiter = ':') {
-    if (this.prefix === null) {
-      const message = this.payload;
-      const includeTimestamp = process.env.LOG_TIMESTAMP === 'true' || !!settings.LOG_TIMESTAMP;
-      const includeEnvironment = process.env.LOG_ENVIRONMENT === 'true' || !!settings.LOG_ENVIRONMENT;
-      const includeLogLevel = process.env.LOG_LEVEL === 'true' || !!settings.LOG_LEVEL;
-      const environment = process.env.NODE_ENV === 'undefined' ? 'local' : process.env.NODE_ENV;
-      this.prefix = {
-        timestamp: includeTimestamp ? `${new Date().toISOString()}${delimiter}` : '',
-        environment: includeEnvironment ? `${environment}${delimiter}` : '',
-        logLevel: includeLogLevel ? `${message.level.toUpperCase()}${delimiter}` : '',
-        reqId: ''
-      };
-      if (message.meta.reqId) {
-        const includeReqId = process.env.LOG_REQID === 'true' || !!settings.LOG_REQID;
-        this.prefix.reqId = includeReqId ? `${message.meta.reqId}` : '';
-      }
-      let isEmpty = true;
-      for (const key in this.prefix) { // eslint-disable-line
-        if (this.prefix[key] !== '') {
-          isEmpty = false;
-          break;
-        }
-      }
-      this.prefix.isEmpty = isEmpty;
+    const message = this.payload;
+    const includeTimestamp = process.env.LOG_TIMESTAMP ?
+      process.env.LOG_TIMESTAMP === 'true' : !!settings.LOG_TIMESTAMP;
+    const includeEnvironment = process.env.LOG_ENVIRONMENT ?
+      process.env.LOG_ENVIRONMENT === 'true' : !!settings.LOG_ENVIRONMENT;
+    const includeLogLevel = process.env.LOG_LEVEL ?
+      process.env.LOG_LEVEL === 'true' : !!settings.LOG_LEVEL;
+    const environment = process.env.NODE_ENV === undefined ?
+      'local' : process.env.NODE_ENV;
+    const includeCallerPrefix = process.env.LOG_CALLER_PREFIX ?
+      process.env.LOG_CALLER_PREFIX === 'true' : !!settings.LOG_CALLER_PREFIX;
+    const prefix = {
+      timestamp: includeTimestamp ? `${new Date().toISOString()}${delimiter}` : '',
+      environment: includeEnvironment ? `${environment}${delimiter}` : '',
+      logLevel: includeLogLevel ? `${message.level.toUpperCase()}${delimiter}` : '',
+      reqId: ''
+    };
+    if (includeCallerPrefix) {
+      Object.assign(prefix, {
+        module: this.callerModuleInfo.module ? `${this.callerModuleInfo.module}${delimiter}` : '',
+        function: this.callerModuleInfo.function ? `${this.callerModuleInfo.function}` : '',
+        project: this.callerModuleInfo.project ? `${this.callerModuleInfo.project}${delimiter}` : ''
+      });
     }
-    return this.prefix;
+    if (message.meta.reqId) {
+      const includeReqId = process.env.LOG_REQID === 'true' || !!settings.LOG_REQID;
+      prefix.reqId = includeReqId ? `${message.meta.reqId}` : '';
+    }
+    let isEmpty = true;
+    for (const key in prefix) { // eslint-disable-line
+      if (prefix[key] !== '') {
+        isEmpty = false;
+        break;
+      }
+    }
+    prefix.isEmpty = isEmpty;
+    return prefix;
   }
 }
 

--- a/src/modules/presets.js
+++ b/src/modules/presets.js
@@ -9,7 +9,8 @@ function configPrefix(include) {
     LOG_TIMESTAMP: include,
     LOG_ENVIRONMENT: include,
     LOG_LEVEL: include,
-    LOG_REQID: include
+    LOG_REQID: include,
+    LOG_CALLER_PREFIX: include
   };
 }
 
@@ -25,11 +26,13 @@ function applyPreset(preset) {
         return {
           CONSOLE_LOGGING: false,
           LOGENTRIES_LOGGING: true,
+          LOGSTASH_LOGGING: true,
           BUGSNAG_LOGGING: true
         };
       }
       return {
         CONSOLE_LOGGING: true,
+        LOGSTASH_LOGGING: false,
         LOGENTRIES_LOGGING: false,
         BUGSNAG_LOGGING: false
       };

--- a/src/modules/tracer.js
+++ b/src/modules/tracer.js
@@ -1,0 +1,63 @@
+const path = require('path');
+
+/**
+ * Traces the caller of the logtify module
+ */
+class Tracer {
+  /**
+   * Try to get the information about caller module
+   * function, that called the module, the name of the file this function is from and the name of the project
+   * This data will be used in prefixes
+   * @return {object} - {
+   *   function: {string}, - name of the callee function. 'anonymous' if none or arrow function
+   *   module: {string}, - name of the parent module
+   *   project: {string} - name of the parent module. Empty if none
+   * }
+   */
+  trace() {
+    try {
+      const callerFileInfo = this.getCallerFileInfo();
+      const callerFunction = callerFileInfo.getFunctionName();
+      const callerModule = callerFileInfo.getFileName().split(path.sep).pop();
+      // if logtify was required using absolute local path or during tests, there is no parent project
+      // So we check if the __dirname has node_modules inside to make sure it was called as a dependency
+      // So if we have __dirname as /var/lib/MyAwesomeProject/node_modules/node-logtify/...
+      // We eventually get MyAwesomeProject
+      const callerProject = __dirname.includes('node_modules') ?
+        __dirname.split(`${path.sep}node_modules${path.sep}`)[0].split(path.sep).pop() : '';
+      return {
+        function: callerFunction || 'anonymous',
+        module: callerModule,
+        project: callerProject
+      };
+    } catch (e) {
+      return {};
+    }
+  }
+
+
+  /**
+   * Get the path to the file from parent project where a logging function was invoked
+   * @return {CallSite} - stack entry with the information about callee file
+   */
+  getCallerFileInfo() {
+    const prepareStack = Error.prepareStackTrace;
+    Error.prepareStackTrace = (_, stack) => stack;
+    // skipping entry under index 0 because it is this (getCallerFileInfo) function that initialized an Error
+    const stack = new Error().stack.slice(1);
+    Error.prepareStackTrace = prepareStack;
+    let i = 0;
+    let stackEntry;
+    // We are not interested in calls of logtify from other dependencies and logtify-related projects
+    // This way we are sure that we get the path to a file from a parent project, not some dependency
+    do {
+      stackEntry = stack[i];
+      ++i;
+    }
+    while (stackEntry.getFileName().includes('logtify') || stackEntry.getFileName().includes('node_modules'));
+    // path to a file that called either adapeter's function or logtify's native function i.e. logger.info() ish or stream.log()
+    return stackEntry;
+  }
+}
+
+module.exports = new Tracer();

--- a/src/subscribers/console-link.js
+++ b/src/subscribers/console-link.js
@@ -65,9 +65,15 @@ class ConsoleLink extends Subscriber {
       const minLogLevel = this.getMinLogLevel(this.settings, this.name);
       if (this.logLevels.get(messageLevel) >= this.logLevels.get(minLogLevel)) {
         const prefix = message.getPrefix(this.settings);
-        const messageText = !prefix.isEmpty ?
-          `[${prefix.timestamp}${prefix.environment}${prefix.logLevel}${prefix.reqId}]${content.text}` :
-          content.text;
+        let prefixText = !prefix.isEmpty ?
+          `[${prefix.timestamp}${prefix.environment}${prefix.logLevel}${prefix.reqId}] ` : '';
+        // if prefix contains these props, then caller module prefix was configured by settings/env
+        if ({}.hasOwnProperty.call(prefix, 'module') &&
+            {}.hasOwnProperty.call(prefix, 'function') &&
+            {}.hasOwnProperty.call(prefix, 'project')) {
+          prefixText += `[${prefix.project}${prefix.module}${prefix.function}] `;
+        }
+        const messageText = `${prefixText}${content.text}`;
         this.winston.log(messageLevel, messageText, content.meta);
       }
     }

--- a/test/modules/message-spec.js
+++ b/test/modules/message-spec.js
@@ -107,14 +107,14 @@ describe('Message class test', () => {
       assert.deepEqual(prefix, this.emptyPrefix);
     });
 
-    it('should return data according to settings [with env]timestamp]', () => {
+    it('should return data according to settings [with env] [timestamp]', () => {
       const message = new Message();
       process.env.LOG_TIMESTAMP = 'false';
       const prefix = message.getPrefix();
       assert.deepEqual(prefix, this.emptyPrefix);
     });
 
-    it('should return data according to settings [with env]timestamp]', () => {
+    it('should return data according to settings [with env] [timestamp]', () => {
       const message = new Message();
       process.env.LOG_TIMESTAMP = 'true';
       const prefix = message.getPrefix();
@@ -132,7 +132,7 @@ describe('Message class test', () => {
       const message = new Message();
       process.env.LOG_ENVIRONMENT = 'true';
       const prefix = message.getPrefix();
-      const environment = process.env.NODE_ENV === undefined ? 'local' : process.env.NODE_ENV;
+      const environment = process.env.NODE_ENV && process.env.NODE_ENV !== 'undefined' ? process.env.NODE_ENV : 'local';
       const notEmptyPrefix = Object.assign({}, this.emptyPrefix, { environment: `${environment}:`, isEmpty: false });
       assert.deepEqual(prefix, notEmptyPrefix);
     });
@@ -202,13 +202,13 @@ describe('Message class test', () => {
       assert({}.hasOwnProperty.call(prefix, 'project'));
     });
 
-    it('should return data according to settings [settings]timestamp]', () => {
+    it('should return data according to settings [settings] [timestamp]', () => {
       const message = new Message();
       const prefix = message.getPrefix({ LOG_TIMESTAMP: false });
       assert.deepEqual(prefix, this.emptyPrefix);
     });
 
-    it('should return data according to settings [settings]timestamp]', () => {
+    it('should return data according to settings [settings] [timestamp]', () => {
       const message = new Message();
       const prefix = message.getPrefix({ LOG_TIMESTAMP: true });
       assert.notDeepEqual(prefix, this.emptyPrefix);
@@ -223,7 +223,7 @@ describe('Message class test', () => {
     it('should return data according to settings [settings] [environment]', () => {
       const message = new Message();
       const prefix = message.getPrefix({ LOG_ENVIRONMENT: true });
-      const environment = process.env.NODE_ENV === undefined ? 'local' : process.env.NODE_ENV;
+      const environment = process.env.NODE_ENV && process.env.NODE_ENV !== 'undefined' ? process.env.NODE_ENV : 'local';
       const notEmptyPrefix = Object.assign({}, this.emptyPrefix, { environment: `${environment}:`, isEmpty: false });
       assert.deepEqual(prefix, notEmptyPrefix);
     });
@@ -262,9 +262,7 @@ describe('Message class test', () => {
     });
 
     it('should return data according to settings [settings] [reqId] [provided]', () => {
-      const message = new Message(null, 'Hello world', {
-        reqId: 'test'
-      });
+      const message = new Message(null, 'Hello world', { reqId: 'test' });
       const prefix = message.getPrefix({ LOG_REQID: true });
       const notEmptyPrefix = Object.assign({}, this.emptyPrefix, { reqId: 'test', isEmpty: false });
       assert.deepEqual(prefix, notEmptyPrefix);
@@ -307,7 +305,7 @@ describe('Message class test', () => {
     it('should be able to change the delimiter', () => {
       const message = new Message(null, 'Hello world');
       const prefix = message.getPrefix({ LOG_ENVIRONMENT: true }, '*');
-      const environment = process.env.NODE_ENV === undefined ? 'local' : process.env.NODE_ENV;
+      const environment = process.env.NODE_ENV && process.env.NODE_ENV !== 'undefined' ? process.env.NODE_ENV : 'local';
       const notEmptyPrefix = Object.assign({}, this.emptyPrefix, { environment: `${environment}*`, isEmpty: false });
       assert.deepEqual(prefix, notEmptyPrefix);
     });

--- a/test/modules/preset-spec.js
+++ b/test/modules/preset-spec.js
@@ -22,6 +22,7 @@ describe('Presets', () => {
     assert.equal(result.LOG_ENVIRONMENT, false);
     assert.equal(result.LOG_LEVEL, false);
     assert.equal(result.LOG_REQID, false);
+    assert.equal(result.LOG_CALLER_PREFIX, false);
   });
 
   it('should return a piece of a config object [prefix]', () => {
@@ -32,11 +33,15 @@ describe('Presets', () => {
     assert.equal(result.LOG_ENVIRONMENT, true);
     assert.equal(result.LOG_LEVEL, true);
     assert.equal(result.LOG_REQID, true);
+    assert.equal(result.LOG_CALLER_PREFIX, true);
   });
 
   it('should return a piece of a config object [dial-once]', () => {
     const result = preset({ presets: ['dial-once'] });
     assert(result);
-    assert(typeof result === 'object');
+    assert.equal(result.CONSOLE_LOGGING, true);
+    assert.equal(result.LOGSTASH_LOGGING, false);
+    assert.equal(result.LOGENTRIES_LOGGING, false);
+    assert.equal(result.BUGSNAG_LOGGING, false);
   });
 });

--- a/test/modules/tracer-spec.js
+++ b/test/modules/tracer-spec.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const Tracer = require('../../src/modules/tracer.js');
+
+describe('tracer module', () => {
+  it('should collect data about caller project', () => {
+    const response = Tracer.trace();
+    assert(response);
+    // these will contain data about mocha module that called executed the test
+    assert(response.module);
+    assert(response.function);
+    // no parent project
+    assert.equal(response.project, '');
+  });
+});


### PR DESCRIPTION
resolves #8 
resolves #6 
resolves #9 

From now on it supports additional prefix:
```
info: [2017-08-25T15:19:58.096Z:local:INFO:] [sample.js:test] Hello world instanceId=spring, notify=true
```
